### PR TITLE
Add second selected song tracking in playback flow

### DIFF
--- a/Dimmer/Dimmer/Dimmer/Orchestration/PlayListMgtFlow.cs
+++ b/Dimmer/Dimmer/Dimmer/Orchestration/PlayListMgtFlow.cs
@@ -217,6 +217,7 @@ public class PlayListMgtFlow : BaseAppFlow, IDisposable
         if (next != null)
         {
             _state.SetCurrentSong(next);
+            _state.SetSecondSelectdSong(next);
             _state.SetCurrentState(DimmerPlaybackState.Playing);
         }
             
@@ -230,6 +231,7 @@ public class PlayListMgtFlow : BaseAppFlow, IDisposable
         {
             _state.SetCurrentSong(prev);
             _state.SetSecondSelectdSong(prev);
+            _state.SetCurrentState(DimmerPlaybackState.Playing);
         }
     }
 


### PR DESCRIPTION
- Introduced `_state.SetSecondSelectdSong(next);` in `PlayNextInQueue` to track the second selected song.
- Added `_state.SetSecondSelectdSong(prev);` in `PlayPreviousInQueue` for consistency in tracking.
- Enhances functionality by allowing simultaneous tracking of the current and second selected songs.

By Yvan Brunel