### PR TITLE
Bump version to 1.9.7a (hotfix release)

### DIFF
--- a/Dimmer/Dimmer/Dimmer.csproj
+++ b/Dimmer/Dimmer/Dimmer.csproj
@@ -9,7 +9,7 @@
 		<UseMaui>true</UseMaui>
 		<Nullable>enable</Nullable>
 		<LangVersion>preview</LangVersion>
-		<Version>1.9.7</Version>
+		<Version>1.9.7a</Version>
 
 
 

--- a/Dimmer/Dimmer/ViewModel/BaseViewModel.cs
+++ b/Dimmer/Dimmer/ViewModel/BaseViewModel.cs
@@ -2071,7 +2071,7 @@ public partial class BaseViewModel : ObservableObject,  IDisposable
     [ObservableProperty]
     public partial string AppTitle { get; set; } = "Dimmer";
 
-    public static string CurrentAppVersion = "1.9.7";
+    public static string CurrentAppVersion = "1.9.7a";
     public static string CurrentAppStage = "Beta";
 
     [ObservableProperty]


### PR DESCRIPTION
Updated project and BaseViewModel to reflect new version 1.9.7a, indicating an alpha or pre-release build.